### PR TITLE
登録画面のリダイレクト先を完了画面から登録画面に変更した

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -35,8 +35,9 @@ class UserController extends Controller
         $data = $this->service->store($request->all());
 
         Session::put('register_token', $data['token']);
+        Session::flash('result_message', trans('admin/message.user.register.complete'));
 
-        return Redirect::route('admin::register-pre_complete', ['user' => $data['user_id']]);
+        return Redirect::route('admin::register');
     }
 
     public function getCreatePreComplete(User $user)

--- a/resources/lang/ja/admin/message.php
+++ b/resources/lang/ja/admin/message.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: yukotanaka
+ * Date: 2019-02-23
+ * Time: 15:26
+ */
+
+return [
+    'user' => [
+        'register' => [
+            'complete' => '社員登録完了',
+        ]
+    ],
+];

--- a/resources/views/admin/elements/form/success_alert.blade.php
+++ b/resources/views/admin/elements/form/success_alert.blade.php
@@ -1,0 +1,7 @@
+<div class="row">
+    <div class="col-md-12">
+        <div class="form-group">
+            <div class="alert alert-success"> {!! Session::get('result_message') !!}</div>
+        </div>
+    </div>
+</div>

--- a/resources/views/admin/register/index.blade.php
+++ b/resources/views/admin/register/index.blade.php
@@ -1,6 +1,9 @@
 @extends('admin.layouts.app')
 @section('content')
 <div class="container">
+    @if(Session::has('result_message'))
+        @include('admin.elements.form.success_alert')
+    @endif
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">


### PR DESCRIPTION
リダイレクト先を完了画面にしていたが、最近の仕様的に元の画面にリダイレクトさせて、メッセージを出すほうが一般的らしいので、そちらに合わせて、完了メッセージを表示することで、完了したということを明示することにした。
